### PR TITLE
Fix Reference.toString() bug in

### DIFF
--- a/dist/bible.js
+++ b/dist/bible.js
@@ -330,7 +330,7 @@ Reference = (function() {
 
   Reference.prototype.toString = function() {
     var bookName, chapterNumber, verseNumber;
-    bookName = books[this.book].names[0];
+    bookName = books[this.book-1].names[0];
     chapterNumber = this.chapter;
     verseNumber = this.verse;
     return "" + bookName + " " + chapterNumber + ":" + verseNumber;


### PR DESCRIPTION
Reference.toString() always returns the next book due to index array;
Bible book count starts from 1 while array index starts from 0;